### PR TITLE
Refine env loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment configuration for EasyProxy
+CERT=cert.pem
+KEY=key.pem
+USERNAME=user
+PASSWORD=pass
+ADDRESS=0.0.0.0:8443
+RUST_LOG=info

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ target/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+
+# Added by cargo
+
+/target
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "EasyProxy"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+tokio-rustls = "0.26"
+rustls-pemfile = "1"
+log = "0.4"
+env_logger = "0.11"
+base64 = "0.21"
+dotenvy = "0.15"

--- a/README.md
+++ b/README.md
@@ -79,3 +79,26 @@ openssl req -x509 -newkey rsa:2048 -nodes ^
   -subj "/CN=proxy.example.com" ^
   -addext "subjectAltName=DNS:proxy.example.com,IP:203.0.113.42"
 ```
+
+## 环境变量配置
+
+代理的证书路径、监听地址以及认证信息均通过环境变量进行配置。可将这些变量写
+入 `.env` 文件并在运行前加载。以下示例给出了全部变量及默认值：
+
+```dotenv
+# .env.example
+CERT=cert.pem
+KEY=key.pem
+USERNAME=user
+PASSWORD=pass
+ADDRESS=0.0.0.0:8443
+# 日志级别，env_logger 根据该变量控制输出
+RUST_LOG=info
+```
+
+使用方法：
+
+```bash
+cp .env.example .env
+cargo run        # 运行代理，自动加载 .env
+```

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,12 @@
+use base64;
+
+pub fn verify_basic_auth(value: &str, username: &str, password: &str) -> bool {
+    if let Some(b64) = value.strip_prefix("Basic ") {
+        if let Ok(decoded) = base64::decode(b64) {
+            if let Ok(s) = String::from_utf8(decoded) {
+                return s == format!("{}:{}", username, password);
+            }
+        }
+    }
+    false
+}

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -1,0 +1,28 @@
+use std::{fs::File, io::BufReader};
+use tokio_rustls::rustls::{Certificate, PrivateKey};
+use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
+
+pub fn load_certs(path: &str) -> std::io::Result<Vec<Certificate>> {
+    let mut reader = BufReader::new(File::open(path)?);
+    let certs = certs(&mut reader)?
+        .into_iter()
+        .map(Certificate)
+        .collect();
+    Ok(certs)
+}
+
+pub fn load_key(path: &str) -> std::io::Result<PrivateKey> {
+    let mut reader = BufReader::new(File::open(path)?);
+    if let Ok(keys) = pkcs8_private_keys(&mut reader) {
+        if let Some(k) = keys.into_iter().next() {
+            return Ok(PrivateKey(k));
+        }
+    }
+    let mut reader = BufReader::new(File::open(path)?);
+    if let Ok(keys) = rsa_private_keys(&mut reader) {
+        if let Some(k) = keys.into_iter().next() {
+            return Ok(PrivateKey(k));
+        }
+    }
+    Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid key"))
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,0 +1,78 @@
+use tokio::{net::TcpStream, io::{AsyncReadExt, AsyncWriteExt}};
+use tokio_rustls::TlsAcceptor;
+use log::{info, error};
+use crate::auth::verify_basic_auth;
+
+pub async fn handle_client(
+    stream: TcpStream,
+    acceptor: TlsAcceptor,
+    username: String,
+    password: String,
+) {
+    let peer = match stream.peer_addr() { Ok(a) => a, Err(_) => return };
+    info!("Connection from {peer}");
+    let mut stream = match acceptor.accept(stream).await {
+        Ok(s) => s,
+        Err(e) => { error!("TLS error from {peer}: {e}"); return; }
+    };
+    info!("TLS established with {peer}");
+    // read headers
+    let mut buf = Vec::new();
+    loop {
+        let mut byte = [0u8;1];
+        match stream.read(&mut byte).await {
+            Ok(0) => return,
+            Ok(_) => {
+                buf.push(byte[0]);
+                if buf.ends_with(b"\r\n\r\n") { break; }
+                if buf.len() > 8192 { error!("header too large from {peer}"); return; }
+            },
+            Err(e) => { error!("read error from {peer}: {e}"); return; }
+        }
+    }
+    let req = match String::from_utf8(buf) { Ok(s) => s, Err(_) => return };
+    let mut lines = req.lines();
+    let first = lines.next().unwrap_or("");
+    let mut parts = first.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let target = parts.next().unwrap_or("");
+    if method != "CONNECT" {
+        let _ = stream.write_all(b"HTTP/1.1 405 Method Not Allowed\r\n\r\n").await;
+        return;
+    }
+    let mut auth_ok = false;
+    for line in lines {
+        if line.is_empty() { break; }
+        if line.to_ascii_lowercase().starts_with("proxy-authorization:") {
+            if let Some(value) = line.splitn(2, ':').nth(1) {
+                let value = value.trim();
+                if verify_basic_auth(value, &username, &password) {
+                    auth_ok = true;
+                }
+            }
+        }
+    }
+    if !auth_ok {
+        let _ = stream.write_all(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n").await;
+        info!("Authentication failed from {peer}");
+        return;
+    }
+    info!("{peer} authenticated, connecting to {target}");
+    let mut remote = match TcpStream::connect(target).await {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = stream.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await;
+            error!("Failed to connect to {target}: {e}");
+            return;
+        }
+    };
+    if stream
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .await
+        .is_err()
+    {
+        return;
+    }
+    let _ = tokio::io::copy_bidirectional(&mut stream, &mut remote).await;
+    info!("Connection with {peer} closed");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,42 @@
+use std::{env, sync::Arc};
+use dotenvy::dotenv;
+use tokio::net::TcpListener;
+use tokio_rustls::rustls::{self, ServerConfig};
+use tokio_rustls::TlsAcceptor;
+use log::info;
+
+mod cert;
+mod auth;
+mod handler;
+
+use cert::{load_certs, load_key};
+use handler::handle_client;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv().ok();
+    env_logger::init();
+    let cert = env::var("CERT").unwrap_or("cert.pem".into());
+    let key = env::var("KEY").unwrap_or("key.pem".into());
+    let user = env::var("USERNAME").unwrap_or("user".into());
+    let pass = env::var("PASSWORD").unwrap_or("pass".into());
+    let addr = env::var("ADDRESS").unwrap_or("0.0.0.0:8443".into());
+
+    let mut config = ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_single_cert(load_certs(&cert)?, load_key(&key)?)?;
+    config.alpn_protocols.push(b"http/1.1".to_vec());
+    let acceptor = TlsAcceptor::from(Arc::new(config));
+
+    let listener = TcpListener::bind(&addr).await?;
+    info!("Listening on https://{addr}");
+
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let acceptor = acceptor.clone();
+        let user = user.clone();
+        let pass = pass.clone();
+        tokio::spawn(async move { handle_client(stream, acceptor, user, pass).await; });
+    }
+}


### PR DESCRIPTION
## Summary
- automatically load variables from `.env`
- document new startup instructions

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo check` *(fails: failed to download dependencies)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685f90f8885083318741d6eb4eb68dc1