### PR TITLE
Add auth header challenge and cleanup

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,9 @@
 use base64::Engine;
 
 pub fn verify_basic_auth(value: &str, username: &str, password: &str) -> bool {
-    if let Some(b64) = value.strip_prefix("Basic ") {
+    const PREFIX: &str = "Basic ";
+    if value.len() > PREFIX.len() && value[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
+        let b64 = &value[PREFIX.len()..];
         if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(b64) {
             if let Ok(s) = String::from_utf8(decoded) {
                 return s == format!("{}:{}", username, password);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -123,7 +123,12 @@ pub async fn handle_client(
         } else {
             info!("认证失败 {peer}: 用户名或密码错误");
         }
-        let _ = stream.write_all(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n").await;
+        let _ = stream
+            .write_all(
+                b"HTTP/1.1 407 Proxy Authentication Required\r\n\
+Proxy-Authenticate: Basic realm=\"EasyProxy\"\r\n\r\n",
+            )
+            .await;
         return;
     }
     


### PR DESCRIPTION
## Summary
- send `Proxy-Authenticate` header when returning 407
- accept `Basic` prefix case-insensitively
- remove README section about SwitchyOmega
- drop the temporary unit tests

## Testing
- `cargo test --quiet` *(fails to fetch dependencies)*
- `cargo build --quiet` *(fails to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685fd09b6ad08331b33b9dd7dfdfe289