### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Build release binary
+        run: cargo build --verbose --release
+      - name: Package artifacts
+        run: |
+          mkdir -p dist
+          cp target/release/EasyProxy dist/
+          cd dist
+          tar czf EasyProxy-${{ github.ref_name }}-linux-amd64.tar.gz EasyProxy
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: EasyProxy-${{ github.ref_name }}
+          path: dist/EasyProxy-${{ github.ref_name }}-linux-amd64.tar.gz
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/EasyProxy-${{ github.ref_name }}-linux-amd64.tar.gz


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to build release binaries

## Testing
- `cargo build --release` *(fails: failed to download index due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685fecff221c833197bd2a64a905f8a7