### PR TITLE
Add logging of connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ log = "0.4"
 simplelog = "0.12"
 base64 = "0.21"
 dotenvy = "0.15"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }


### PR DESCRIPTION
## Summary
- track incoming connection info in a new `connections.txt`
- log timestamp, client IP and requested target
- add `chrono` dependency for time handling

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68607e3e84448331bda4ec69514dc056